### PR TITLE
Requirement loading order

### DIFF
--- a/lib/citeproc.rb
+++ b/lib/citeproc.rb
@@ -59,12 +59,14 @@ require 'citeproc/bibliography'
 require 'citeproc/formatter'
 require 'citeproc/processor'
 
+
+require 'plugins/formats/default'
+
 # Load filter and format plugins
 Dir.glob("#{File.expand_path('..', __FILE__)}/plugins/formats/*.rb").each do |format|
   require format
 end
 
-require 'plugins/formats/default'
 
 Dir.glob("#{File.expand_path('..', __FILE__)}/plugins/filters/*.rb").each do |format|
   require format


### PR DESCRIPTION
Hi,

I had a problem when loading your application :

 NameError: uninitialized constant CiteProc::Format::Default
        from citeproc-ruby-0.0.1/lib/plugins/formats/html.rb:3:in `module:Format'

So I changed the loading order to be ensure  Default class to be loaded before HTML.

The first time I deployed citeproc, it worked but not the second time. It seems a little bit haphazard…
By the way, thanks for your application!
