### PR TITLE
Additional stopwords

### DIFF
--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -10,19 +10,13 @@ module CiteProc
       @squeezable = /^[\s\.,:;!?\)\(\[\]]+$/
 
       @stopwords = {
-        :en => [
-          'about', 'above', 'across', 'afore', 'after', 'against', 'along',
-          'alongside', 'amid', 'amidst', 'among', 'amongst', 'anenst', 'apropos',
-          'apud', 'around', 'as', 'aside', 'astride', 'at', 'athwart', 'atop',
-          'barring', 'before', 'behind', 'below', 'beneath', 'beside', 'besides',
-          'between', 'beyond', 'but', 'by', 'circa', 'despite', 'd', 'down', 'during',
-          'except', 'for', 'forenenst', 'from', 'given', 'in', 'inside', 'into',
-          'lest', 'like', 'modulo' 'near', 'next', 'notwithstanding', 'of', 'off',
-          'on', 'onto', 'out', 'over', 'per', 'plus', 'pro', 'qua', 'sans', 'since',
-          'than', 'through', 'thru', 'throughout', 'thruout', 'till', 'to', 'toward',
-          'towards', 'under', 'underneath', 'until', 'unto', 'up', 'upon', 'versus',
-          'vs', 'v', 'via', 'vis-à-vis', 'with', 'within', 'without'
-        ]
+        :en => %w(a about above across afore after against along alongside amid amidst among amongst
+          an and anenst apropos apud around as aside astride at athwart atop barring before behind
+          below beneath beside besides between beyond but by circa despite d down during except for
+          forenenst from given in inside into lest like modulo near next nor notwithstanding of off
+          on onto or out over per plus pro qua sans since so than the through thru throughout thruout
+          till to toward towards under underneath until unto up upon versus vs v via vis-à-vis with
+          within without)
       }
 
       class << self


### PR DESCRIPTION
https://github.com/citation-style-language/documentation/blob/master/specification.txt says that words like 'a', 'and', 'the', 'nor', etc. should be stopwords for title case capitalization. Some of those given in the spec were missing from citeproc-ruby.

This was causing invalid capitalization for styles (like MLA) that use title case, e.g. _Declaration on Democracy, Political, Economic And Corporate Governance._ Clearly 'and' should not be capitalized here.

I have added them. I also changed to the terser %w array init syntax.

Thanks for considering!
