### PR TITLE
Support the citation-label standard variable

### DIFF
--- a/lib/citeproc/ruby/renderer/text.rb
+++ b/lib/citeproc/ruby/renderer/text.rb
@@ -40,7 +40,9 @@ module CiteProc
 
           when node.variable == 'page-first' && text.empty?
             text = item.data[:'page'].to_s[/\d+/].to_s
-
+        
+          when node.variable == 'citation-label'
+            text = item[:id]
           end
 
           text


### PR DESCRIPTION
This will output the processed item's `:id` when a `citation-label` variable value is requested in a CSL style.