### PR TITLE
title-case capitalization: always capitalize first and last word

### DIFF
--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -229,14 +229,17 @@ module CiteProc
           # TODO add support for stop words consisting of multiple words
           #output.gsub!(/\b(\p{Lu})(\p{Lu}+)\b/) { "#{$1}#{CiteProc.downcase($2)}" }
 
-          # TODO exceptions: first, last word; followed by colon
+          # TODO exceptions: word followed by colon
+          first = true
           output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
-            if Format.stopword?(word)
+            if Format.stopword?(word) and not first
               word
             else
+              first = false
               "#{CiteProc.upcase($1)}#{$2}"
             end
           end
+          output.gsub!(/\b(\p{Ll})(\p{L}+)\b$/) { "#{CiteProc.upcase($1)}#{$2}" }
 
         end
       end

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -106,8 +106,11 @@ module CiteProc
           node[:'text-case'] = 'title'
 
           expect(format.apply('The adventures of Huckleberry Finn', node)).to eq('The Adventures of Huckleberry Finn')
-          expect(format.apply("This IS a pen that is a smith pencil", node)).to eq('This IS a Pen That Is a Smith Pencil')
-          #format.apply('of mice and men', node).should == 'Of Mice And Men'
+          expect(format.apply('This IS a pen that is a smith pencil', node)).to eq('This IS a Pen That Is a Smith Pencil')
+          expect(format.apply('of mice and men', node)).to eq('Of Mice and Men')
+          expect(format.apply('history of the word the', node)).to eq('History of the Word The')
+          expect(format.apply('faster than the speed of sound', node)).to eq('Faster than the Speed of Sound')
+          expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
         end
       end
 


### PR DESCRIPTION
as per http://docs.citationstyles.org/en/stable/specification.html#title-case-conversion

A related issue - the list of stop-words here don't actually match the ones given in the spec above. I mean, they are all in there, but there are also many additional ones in here. I could PR that change but I thought I'd first ask if there's a specific reason/source for the stop words you use in this repo.