### PR TITLE
fix: render the group when its content is a substituted names item

### DIFF
--- a/lib/citeproc/ruby/renderer/names.rb
+++ b/lib/citeproc/ruby/renderer/names.rb
@@ -327,6 +327,8 @@ module CiteProc
             string = render(item, child)
 
             unless string.empty?
+              item.data.changed true
+              item.data.notify_observers :read, node.parent[:variable], string
               # Variables rendered as substitutes
               # must be suppressed during the remainder
               # of the rendering process!

--- a/spec/citeproc/ruby/renderer/group_spec.rb
+++ b/spec/citeproc/ruby/renderer/group_spec.rb
@@ -83,6 +83,32 @@ module CiteProc
           end
         end
       end
+
+      describe 'when there is a names node with substitute in the group' do
+
+        before(:each) do
+          subst = CSL::Style::Substitute.new()
+          subst << CSL::Style::Text.new( :value => 'Anonymous') 
+          names = CSL::Style::Names.new( :variable => 'author')
+          names << subst
+          node << names
+        end
+
+        describe 'when the variable is set' do
+          before(:each) { item.data.author = 'Some Author' }
+
+          it 'returns the content of the nested node' do
+            expect(renderer.render_group(item, node)).to eq('Some Author')
+          end
+        end
+
+        describe 'when the variable is not set' do
+          it 'returns the substitution of the nested node' do
+            expect(renderer.render_group(item, node)).to eq('Anonymous')
+          end
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
The fix feels pretty hacky to me, but I don't know how to do that in a better way. But I guess the test is still valuable :) Feedback/comments much appreciated, obviously.

The issue is that groups containing substituted `names` items wouldn't render at all, even if there was actually something substituted for the missing variable.