### PR TITLE
Fix title casing

### DIFF
--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -231,13 +231,16 @@ module CiteProc
 
           # TODO exceptions: word followed by colon
           first = true
-          output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
-            if Format.stopword?(word) and not first
-              word
-            else
-              first = false
-              "#{CiteProc.upcase($1)}#{$2}"
+          # output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
+          output.gsub!(/\b(\p{L})(\p{L}+)\b/) do |word|
+            first_letter = $1
+            rest_of_word = $2
+            result = word
+            if first_letter.match(/^\p{Ll}/) && (!Format.stopword?(word) || first)
+              result = "#{CiteProc.upcase(first_letter)}#{rest_of_word}"
             end
+            first = false
+            result
           end
           output.gsub!(/\b(\p{Ll})(\p{L}+)\b$/) { "#{CiteProc.upcase($1)}#{$2}" }
 

--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -231,19 +231,29 @@ module CiteProc
 
           # TODO exceptions: word followed by colon
           first = true
-          # output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
-          output.gsub!(/\b(\p{L})(\p{L}+)\b/) do |word|
+          output.gsub!(/\b(\p{L})([\p{L}\.]+)\b/) do |word|
             first_letter = $1
             rest_of_word = $2
             result = word
+
             if first_letter.match(/^\p{Ll}/) && (!Format.stopword?(word) || first)
               result = "#{CiteProc.upcase(first_letter)}#{rest_of_word}"
             end
             first = false
             result
           end
-          output.gsub!(/\b(\p{Ll})(\p{L}+)\b$/) { "#{CiteProc.upcase($1)}#{$2}" }
 
+          output.gsub!(/(\.|\b)(\p{Ll})([\p{L}\.]+)\b$/) do |word|
+            word_boundary = $1
+            first_letter = $2
+            rest_of_word = $3
+
+            if word_boundary == '.'
+              word
+            else
+              "#{CiteProc.upcase($2)}#{$3}"
+            end
+          end
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -115,6 +115,8 @@ module CiteProc
           expect(format.apply("The Mote in God eye", node)).to eq("The Mote in God Eye")
           expect(format.apply("Music community mourns death of one of its leaders", node)).to eq("Music Community Mourns Death of One of Its Leaders")
           expect(format.apply("Pride and Prejudice", node)).to eq("Pride and Prejudice")
+          expect(format.apply("Check the page: easybib.com", node)).to eq("Check the Page: Easybib.com")
+          expect(format.apply("Dogs life.obviously the best guide for pet owners", node)).to eq("Dogs Life.obviously the Best Guide for Pet Owners")
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -111,6 +111,7 @@ module CiteProc
           expect(format.apply('history of the word the', node)).to eq('History of the Word The')
           expect(format.apply('faster than the speed of sound', node)).to eq('Faster than the Speed of Sound')
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
+          expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -112,6 +112,7 @@ module CiteProc
           expect(format.apply('faster than the speed of sound', node)).to eq('Faster than the Speed of Sound')
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
           expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
+          expect(format.apply("The Mote in God eye", node)).to eq("The Mote in God Eye")
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -113,6 +113,8 @@ module CiteProc
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
           expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
           expect(format.apply("The Mote in God eye", node)).to eq("The Mote in God Eye")
+          expect(format.apply("Music community mourns death of one of its leaders", node)).to eq("Music Community Mourns Death of One of Its Leaders")
+          expect(format.apply("Pride and Prejudice", node)).to eq("Pride and Prejudice")
         end
       end
 


### PR DESCRIPTION
cite-proc had a problem "counting" words in a string when looking for capitalization of them.

The rule that it tried to model is: "Capitalize all words if they are not a stopword or if they are the first word".

What cite-proc actually did: "Capitalize all words if they are not a stopword or if they are the first lower letter word."

This PR changes the regex to match not only words starting with a lower letter but matching all words. This way the code can determine the first word correctly - also moves the "lower letter" check that was in the surrounding regex into it's separate check inside of the gsub! block.