### PR TITLE
Makes the date renderer aware of literal dates

### DIFF
--- a/lib/citeproc/ruby/renderer/date.rb
+++ b/lib/citeproc/ruby/renderer/date.rb
@@ -13,6 +13,8 @@ module CiteProc
         date = item.data[node.variable]
         return '' if date.nil? || date.empty?
 
+        return date.to_s if date.literal?
+
         # TODO date-ranges
 
         if node.localized?

--- a/spec/citeproc/ruby/engine_spec.rb
+++ b/spec/citeproc/ruby/engine_spec.rb
@@ -40,6 +40,7 @@ module CiteProc
           cp << items(:grammatology).data
           cp << items(:knuth1968).data
           cp << items(:difference).data
+          cp << items(:literal_date).data
         end
 
         it 'renders the reference for the given id' do
@@ -61,6 +62,10 @@ module CiteProc
 
           cp.options[:allow_locale_overrides] = true
           expect(cp.render(:bibliography, :id => 'difference')).to eq(['Derrida, J. (1967). L’écriture et la différence (1ʳᵉ éd.). Paris: Éditions du Seuil.'])
+        end
+
+        it 'can handle literal dates' do
+          expect(cp.render(:bibliography, :id => 'literal_date')).to eq(['Derrida, J. (sometime in 1967). L’écriture et la différence (1st ed.). Paris: Éditions du Seuil.'])
         end
       end
     end

--- a/spec/fixtures/items.rb
+++ b/spec/fixtures/items.rb
@@ -72,6 +72,19 @@ module Fixtures
         :language => 'fr',
         :publisher => 'Éditions du Seuil',
         :'publisher-place' => 'Paris'
+      ),
+
+      :literal_date => CiteProc::Item.new(
+        :id => 'literal_date',
+        :type => 'book',
+        :title => 'L’écriture et la différence',
+        :author => @people[:derrida],
+        :issued => { 'literal' => 'sometime in 1967' },
+        :edition => 1,
+        :pages => 446,
+        :language => 'fr',
+        :publisher => 'Éditions du Seuil',
+        :'publisher-place' => 'Paris'
       )
 
     }


### PR DESCRIPTION
This makes the date renderer aware of "*literal*" dates in a citation. It is possible to feed CiteProc with the usual ``date-parts`` array as a date e.g.: ``"issued": { "date-parts": [ [ 2016, 3, 27 ] ] }`` but you can also support a literal value like this: ``"issued":{ "literal": "Summer" }``. The latter should be exposed as ``Summer`` in any rendered citation.