### PR TITLE
Fix for issue #42

### DIFF
--- a/lib/citeproc/ruby/formats/default.rb
+++ b/lib/citeproc/ruby/formats/default.rb
@@ -17,6 +17,56 @@ module CiteProc
 
       end
 
+      class Sort < Text
+        #A special format to use when sorting which prevents formatting of extraneous things like quotes
+
+        def apply(input, node, locale = nil)
+          return '' if input.nil?
+          return input if input.empty? || node.nil?
+
+          return ArgumentError unless node.respond_to?(:formatting_options)
+
+
+          @input, @output, @node, @locale = input, input.dup, node, locale
+
+          setup!
+
+          # NB: Layout nodes apply formatting to
+          # affixes; all other nodes do not!
+          if node.is_a? CSL::Style::Layout
+            apply_prefix if options.key?(:prefix)
+            apply_suffix if options.key?(:suffix)
+          end
+
+          keys.each do |format|
+            if options.key?(format)
+              method = "apply_#{format}".tr('-', '_')
+              send method if respond_to?(method)
+            end
+          end unless options.empty?
+
+          output.gsub!(/\.+/, '') if node.strip_periods?
+
+          #Do not apply quotes when sorting
+          #apply_quotes if node.quotes? && !locale.nil?
+
+          finalize_content!
+
+          unless node.is_a? CSL::Style::Layout
+            apply_prefix if options.key?(:prefix)
+            apply_suffix if options.key?(:suffix)
+          end
+
+          apply_display if options.key?(:display)
+
+          finalize!
+
+          output
+        ensure
+          cleanup!
+        end
+      end
+
       class Debug < Format
       end
 

--- a/lib/citeproc/ruby/renderer.rb
+++ b/lib/citeproc/ruby/renderer.rb
@@ -102,7 +102,7 @@ module CiteProc
         state.store! nil, key
 
         original_format = @format
-        @format = Formats::Text.new
+        @format = Formats::Sort.new
 
         if a.is_a?(CiteProc::Names)
           [render_name(a, node), render_name(b, node)]

--- a/lib/citeproc/ruby/sort.rb
+++ b/lib/citeproc/ruby/sort.rb
@@ -4,7 +4,7 @@ module CiteProc
     module SortItems
 
       def sort!(items, keys)
-        return itmes unless !keys.nil? && !keys.empty?
+        return items unless !keys.nil? && !keys.empty?
 
         # TODO refactor
         if items.is_a?(CitationData)
@@ -41,7 +41,7 @@ module CiteProc
           # Return early if one side is nil. In this
           # case ascending/descending is irrelevant!
           return  1 if va.nil? || va.empty?
-          return -1 if vb.nil? || va.empty?
+          return -1 if vb.nil? || vb.empty?
 
           result = case CiteProc::Variable.types[key.variable]
             when :names

--- a/spec/citeproc/ruby/engine_spec.rb
+++ b/spec/citeproc/ruby/engine_spec.rb
@@ -27,7 +27,28 @@ module CiteProc
           expect(cp.bibliography(:none => {})).to be_empty
         end
       end
+      describe 'should order entries correctly' do
+        describe 'mla 8' do
+          let(:cp_mla) { CiteProc::Processor.new :style => 'modern-language-association-8th-edition', :format => 'html' }
+          before(:each) do
+            cp_mla << items(:aaron2).data
+            cp_mla << items(:abbott).data
+            cp_mla << items(:knuth1968).data
+          end
 
+          it 'should not add quotes around text items when rendering for sorting purposes' do
+            cp_bib1_hash = cp_mla.bibliography.to_citeproc
+            bib_entries = cp_bib1_hash[1]
+            expect(bib_entries[0]).to start_with('Aaron')
+            # no author specified on Abbott.  In MLA8 title is a substitute for name, thus it was being rendered in text
+            # format to get a sortable value for author.  This produced a string starting with a quote character which
+            # messed up sorting.  Have created a special sort format which is overridden to not inject these quotes.
+            # may be other things that could be prevented here (suffix/prefix) but I haven't run across them yet
+            expect(bib_entries[1]).to start_with('“Abbott')
+            expect(bib_entries[2]).to start_with('Knuth')
+          end
+        end
+      end
     end
 
     describe '#render' do

--- a/spec/fixtures/items.rb
+++ b/spec/fixtures/items.rb
@@ -85,8 +85,28 @@ module Fixtures
         :language => 'fr',
         :publisher => 'Éditions du Seuil',
         :'publisher-place' => 'Paris'
-      )
+      ),
 
+      :aaron1 => CiteProc::Item.new(
+          type: 'website',
+          id: 2,
+          author: [{given: 'Hank', family: 'Aaron'}],
+          title: 'Spitball'
+      ),
+
+      :aaron2 => CiteProc::Item.new(
+          type: 'website',
+          id: 3,
+          author: [{given: 'Hank', family: 'Aaron'}],
+          title: 'Baseball Fever'
+      ),
+
+      :abbott => CiteProc::Item.new(
+          type: 'website',
+          id: 4,
+          title: 'Abbott and Costello',
+          :'container-title' => 'McMillan'
+      )
     }
   end
 

--- a/spec/fixtures/styles/modern-language-association-8th-edition.csl
+++ b/spec/fixtures/styles/modern-language-association-8th-edition.csl
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+  <info>
+    <title>Modern Language Association 8th edition</title>
+    <title-short>MLA</title-short>
+    <id>http://www.zotero.org/styles/modern-language-association-8th-edition</id>
+    <link href="http://www.zotero.org/styles/modern-language-association-8th-edition" rel="self"/>
+    <link href="http://style.mla.org" rel="documentation"/>
+    <author>
+      <name>Sebastian Karcher</name>
+    </author>
+    <category citation-format="author"/>
+    <category field="generic-base"/>
+    <summary>This style adheres to the MLA 8th edition handbook. Follows the structure of references as outlined in the MLA Manual closely</summary>
+    <updated>2014-07-06T20:05:10+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <date form="text">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" " form="short"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="month-01" form="short">Jan.</term>
+      <term name="month-02" form="short">Feb.</term>
+      <term name="month-03" form="short">Mar.</term>
+      <term name="month-04" form="short">Apr.</term>
+      <term name="month-05" form="short">May</term>
+      <term name="month-06" form="short">June</term>
+      <term name="month-07" form="short">July</term>
+      <term name="month-08" form="short">Aug.</term>
+      <term name="month-09" form="short">Sept.</term>
+      <term name="month-10" form="short">Oct.</term>
+      <term name="month-11" form="short">Nov.</term>
+      <term name="month-12" form="short">Dec.</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="first" and="text" delimiter-precedes-last="always" delimiter-precedes-et-al="always" initialize="false" initialize-with=". "/>
+      <label form="long" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title-short"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <group delimiter=", ">
+      <names variable="author">
+        <name form="short" initialize-with=". " and="text"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text macro="title-short"/>
+        </substitute>
+      </names>
+      <choose>
+        <if disambiguate="true">
+          <text macro="title-short"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="container-title" match="any">
+        <text variable="title" quotes="true"/>
+      </if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="container-title" match="any">
+        <text variable="title" form="short" quotes="true"/>
+      </if>
+      <else>
+        <text variable="title" form="short" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <text variable="container-title" font-style="italic"/>
+  </macro>
+  <macro name="other-contributors">
+    <choose>
+      <if variable="container-title" match="any">
+        <names variable="editor translator" delimiter=", ">
+          <label form="verb" suffix=" "/>
+          <name and="text"/>
+        </names>
+      </if>
+      <else>
+        <names variable="editor translator" delimiter=", ">
+          <label form="verb" suffix=" " text-case="capitalize-first"/>
+          <name and="text"/>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="version">
+    <group delimiter=", ">
+      <choose>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <text term="edition" form="short"/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="number">
+    <group delimiter=", ">
+      <group>
+        <choose>
+          <!--lowercase if we have a preceding element-->
+          <if variable="edition container-title" match="any">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <!--other contributors preceding the volume-->
+          <else-if variable="author editor" match="all">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </else>
+        </choose>
+      </group>
+      <group delimiter=" ">
+        <text term="issue" form="short"/>
+        <text variable="issue"/>
+      </group>
+      <choose>
+        <if type="report">
+          <text variable="genre"/>
+        </if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher"/>
+  </macro>
+  <macro name="publication-date">
+    <choose>
+      <if type="book chapter paper-conference motion_picture" match="any">
+        <date variable="issued" form="numeric" date-parts="year"/>
+      </if>
+      <else-if type="article-journal article-magazine" match="any">
+        <date variable="issued" form="text" date-parts="year-month"/>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <date variable="issued" form="text"/>
+      </else-if>
+      <else-if type="speech" match="none">
+        <date variable="issued" form="text"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="location">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <label variable="page" form="short"/>
+        <text variable="page"/>
+      </group>
+      <choose>
+        <if variable="source" match="none">
+          <choose>
+            <if variable="URL DOI" match="any">
+              <text macro="URI"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container2-title">
+    <group delimiter=", ">
+      <choose>
+        <if type="speech">
+          <text variable="event"/>
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+      <text variable="archive_location"/>
+    </group>
+  </macro>
+  <macro name="container2-location">
+    <choose>
+      <if variable="source">
+        <group delimiter=", ">
+          <text variable="source" font-style="italic"/>
+          <text macro="URI"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="URI">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </if>
+      <else>
+        <text variable="URL"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="accessed">
+    <!--using accessed where we don't have an issued date; follows recommendation on p. 53 -->
+    <choose>
+      <if variable="issued" match="none">
+        <group delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <choose>
+        <if locator="page">
+          <group delimiter=" ">
+            <text macro="author-short"/>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-short"/>
+            <group>
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="3" et-al-use-first="1" line-spacing="2" entry-spacing="0" subsequent-author-substitute="---">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text macro="title"/>
+        <date variable="original-date" form="numeric" date-parts="year"/>
+        <group delimiter=", ">
+          <!---This group corresponds to MLA's "Container 1"-->
+          <text macro="container-title"/>
+          <text macro="other-contributors"/>
+          <text macro="version"/>
+          <text macro="number"/>
+          <text macro="publisher"/>
+          <text macro="publication-date"/>
+          <text macro="location"/>
+        </group>
+        <group delimiter=", ">
+          <!---This group corresponds to MLA's "Container 2"-->
+          <!--currently just using this one for archival info-->
+          <text macro="container2-title"/>
+          <text macro="container2-location"/>
+        </group>
+        <text macro="accessed"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
I've introduced a new format called `sort` which extends `text` and overrides it to prevent the generation of the quotes during rendering.  I've changed the `sort!` method to use this format (previously it forced `text` format).

I've added the mla8 csl as part of the test suite so I could demonstrate the bug and then fix it.

Also, there's a commit that fixes two typos in `sort.rb` I noticed while digging into this problem.

Please let me know if I missed a better way to do accomplish this.