### PR TITLE
Renderer allows re-use of a passed in Locale object instead of reload

### DIFF
--- a/lib/citeproc/ruby/renderer.rb
+++ b/lib/citeproc/ruby/renderer.rb
@@ -15,7 +15,8 @@ module CiteProc
           @engine = options_or_engine
         when Hash
           locale, format = options_or_engine.values_at(:locale, :format)
-          @locale, @format = CSL::Locale.load(locale), Format.load(format)
+          @locale = locale.is_a?(CSL::Locale) ? locale : CSL::Locale.load(locale)
+          @format = Format.load(format)
         end
       end
 


### PR DESCRIPTION
Ref #53

CiteProc::Ruby::Engine class already does it here for styles:
    https://github.com/inukshuk/citeproc-ruby/blob/c6b81ea04868ad2afc704d9a38148df053cf4898/lib/citeproc/ruby/engine.rb#L117-L121

And CiteProc::Ruby::Format does it here for formats:
    https://github.com/inukshuk/citeproc-ruby/blob/c6b81ea04868ad2afc704d9a38148df053cf4898/lib/citeproc/ruby/format.rb#L31

Loading (or not) of all three types of objects is done in kind of different non-parallel ways, but that was kind of there in the code when I found it.

With this change for locale, I can avoid loading both locales AND styles (as well as formats while we’re at it although it probably doesn’t make as much of a difference) with EITHER of these APIs:

```ruby
csl_style # assume exists a CSL::Style, prob previously loaded with CSL::Style.load
csl_locale # assume exists a CSL::Style, prob previously loaded with CSL::Locale.load

    cp = CiteProc::Processor.new style: csl_style,
       locale: csl_locale,
       format: CiteProc::Ruby::Formats::Html.new
    cp.import csl
    cp.render :bibliography, id: whatever

   csl_hash # assume exists, a single hash (not array) that’s csl-data.json format
   citation_item = CiteProc::CitationItem.new(id: csl_hash[“id"]) do |c|
      c.data = CiteProc::Item.new(csl)
    end

      renderer = CiteProc::Ruby::Renderer.new :format => CiteProc::Ruby::Formats::Html.new,
         :style => csl_style, :locale => csl_locale
      renderer.render citation_item, csl_style.bibliography
```

The latter is giving me pretty good performance, 7-9ms on my macbook, with already loaded style/locale.

The former still gives better performance than it did before an already loaded locale could be used.

There’s other code here:
https://github.com/inukshuk/citeproc-ruby/blob/c6b81ea04868ad2afc704d9a38148df053cf4898/lib/citeproc/ruby/renderer/locale.rb#L11

…that at first I was looking at to avoid the load if it already has a locale…. I’m not totally sure when that code is used vs the code I _did_ patch, but the thing I’m PR’ing here is the thing that seemed to work for both CiteProc::Processor use and CiteProc::Renderer use.  I think.

None of these approaches were obvious from the docs. Perhaps a README PR giving examples of how to do this now with current code?  Better convenience API for this use case might also be nice, but I’m not totally sure how to do it sensibly.  Maybe just a new method on Renderer that lets you just pass in a csl_hash, without having to make the CitationItem yourself, and lets you pass in :bibliography if you want. (And why do I have to tell CitationItem the `id`, when that’s already in the hash?)

Or maybe the convenience API should actually be in terms of `Engine`, create an engine and just pass that in to render each time. Which maybe is possible now. I gotta figure out how to work with Engine directly. Is `Engine` thread-safe do you think?  If not, then nevermind on this last paragraph.