### PR TITLE
Fix warnings about uninitialized instance variables

### DIFF
--- a/lib/citeproc/ruby/formats/html.rb
+++ b/lib/citeproc/ruby/formats/html.rb
@@ -140,7 +140,9 @@ module CiteProc
 
         def finalize_content!
           super
-          output.replace content_tag(config[:container], output, 'style' => css) if @css
+          if instance_variable_defined?("@css")
+            output.replace content_tag(config[:container], output, 'style' => css) if @css
+          end
         end
 
         def finalize!

--- a/lib/citeproc/ruby/renderer/state.rb
+++ b/lib/citeproc/ruby/renderer/state.rb
@@ -80,6 +80,7 @@ module CiteProc
         end
 
         def rendered_names?
+          @names = false unless instance_variable_defined?("@names")
           @names
         end
 


### PR DESCRIPTION
Fixes warning in formats/html.rb on line 243 about @css
and warning in renderer/state.rb on line 83 about @names
by first checking if the instance variable is defined.