### PR TITLE
Capitalize-first does not capitalize first letter in ordinal number

### DIFF
--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -214,7 +214,7 @@ module CiteProc
           output.replace CiteProc.upcase output
 
         when 'capitalize-first'
-          output.sub!(/^([^\p{L}]*)(\p{Ll})/) { "#{$1}#{CiteProc.upcase($2)}" }
+          output.sub!(/^([^\p{Alnum}]*)(\p{Ll})/) { "#{$1}#{CiteProc.upcase($2)}" }
 
         when 'capitalize-all'
           output.gsub!(/\b(\p{Ll})/) { CiteProc.upcase($1) }

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -86,6 +86,13 @@ module CiteProc
           expect(format.apply('én foo bar', node)).to eq('Én foo bar')
         end
 
+        it 'supports capitalize-first with ordinal numbers' do
+          node[:'text-case'] = 'capitalize-first'
+
+          expect(format.apply('1st edition', node)).to eq('1st edition')
+          expect(format.apply('first edition', node)).to eq('First edition')
+        end
+
         it 'supports capitalize-all' do
           node[:'text-case'] = 'capitalize-all'
 


### PR DESCRIPTION
A lot of our edition statements particularly were looking odd for ordinal numbers with values like "1St edition".