### PR TITLE
Reject empty when rendering choose block

### DIFF
--- a/lib/citeproc/ruby/renderer/choose.rb
+++ b/lib/citeproc/ruby/renderer/choose.rb
@@ -24,7 +24,7 @@ module CiteProc
 
         join node.each_child.map { |child|
           render item, child
-        }, closest_delimiter_for(node)
+        }.reject(&:empty?), closest_delimiter_for(node)
       end
 
       def closest_delimiter_for(node)


### PR DESCRIPTION
When we updated to csl-styles 2.0.2 we started seeing test failures for our `chicago-author-date` citations due to seemingly empty strings. I think I've tracked it down to the choose rendering, which the updated style seems to make extensive use of.

For example:
```rb
search-works(dev):050> cp = CiteProc::Processor.new style: 'chicago-author-date', format: 'text'
search-works(dev):051* cp.import [{
search-works(dev):052*   id: 'test',
search-works(dev):053*   type: 'book',
search-works(dev):054*   author: [{family: 'Strom', given: 'Dao'}],
search-works(dev):055*   issued: {'date-parts' => [[2020]]},
search-works(dev):056*   title: 'Instrument',
search-works(dev):057*   publisher: 'Fonograf Editions',
search-works(dev):058*   'publisher-place': 'Portland',
search-works(dev):059*   edition: 'First edition'
search-works(dev):060> }]
search-works(dev):061>
search-works(dev):062> puts cp.render(:bibliography, id: 'test')
Strom, Dao. 2020. Instrument. . . . First edition. . . . . Fonograf Editions. .
```

With this update it's `Strom, Dao. 2020. Instrument. First edition. Fonograf Editions.`

This seems to follow existing patterns:
https://github.com/inukshuk/citeproc-ruby/blob/10293f14f53f8168732c4fc9411931effd224a7a/lib/citeproc/ruby/renderer/layout.rb#L14
https://github.com/inukshuk/citeproc-ruby/blob/10293f14f53f8168732c4fc9411931effd224a7a/lib/citeproc/ruby/renderer/group.rb#L18